### PR TITLE
Add LTO support and corresponding documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,57 +8,63 @@ Using SoftBoundCETS with LLVM+CLANG-3.4 on a x86-64 machine with Linux OS
 =========================================================================
 
 
-(1) Download the github repository from http://www.github.com/santoshn/softboundcets-34
+1. Download the github repository from http://www.github.com/santoshn/softboundcets-34
 
-(2) Goto directory softboundcets-lib
+2. Build SoftBoundCETS for LLVM+3.4
 
-(3) Build the softboundcets instrumenter library by typing "make" in
-softboundcets-lib directory
+   1. Goto to directory softboundcets-llvm-clang34 by executing the following command
 
-(4) Build SoftBoundCETS for LLVM+3.4 
+            cd softboundcets-llvm-clang34
 
-   (a) Goto to directory softboundcets-llvm-clang34 by executing the following command
+   2. Configure LLVM, clang and softboundcets with the following command
 
-      cd softboundcets-llvm-clang34
+            ./configure --enable-assertions --disable-optimized
 
-   (b) Configure the llvm, clang and softboundcets with the following command
+      If you prefer a faster compiler and do not need to debug SoftBoundCETS,
+      use `--enable-optimized`.
 
-     ./configure --enable-assertions --disable-optimized
+      If you want to use SoftBoundCETS with LTO, follow the instructions at
+      http://llvm.org/docs/GoldPlugin.html and add the
+      `--with-binutils-include=/usr/include` parameter. Replace `/usr/include` by
+      the folder that contains the `plugin-api.h` file.
 
-   (c) Build softboundcets, llvm, clang with the following command
-     
-      make -j8
+   3. Build softboundcets, LLVM, clang with the following command
 
-(5) Running a program with softboundcets
- 
-    (a) Set PATH environment variable to point to binary directory
+            make -j8
 
-     	For example in bash, it would be
+3. Set up your environment to use SoftBoundCETS
 
-	export PATH=<git_repo>/softboundcets-llvm-clang34/Debug+Asserts/bin:$PATH
-	export LD_LIBRARY_PATH=<git_repo>/softboundcets-lib/
+   For example in bash, it would be
 
+         export PATH=<git_repo>/softboundcets-llvm-clang34/Debug+Asserts/bin:$PATH
 
-    (b) Goto to tests directory with the following command
+   If you compiled an optimized build, the path is `Release+Asserts` instead of
+   `Debug+Asserts`.
 
-        cd tests
-	clang -fsoftboundcets test.c -o test.out -L/<git_repo>/softboundcets-lib/ -lm
+4. Compile the SoftBoundCETS runtime library
 
-	
-    (c) Run the test program
+         cd <git_repo>
+         cd softboundcets-lib
+         make
 
-        ./test.out
+   If you compiled the LLVM gold plugin, add the line below before calling
+   make, in order to also build the SoftBoundCETS runtime library with LTO
+   support.
 
-	enter 10
+         export LLVM_GOLD=<git_repo>/softboundcets-llvm-clang34/Debug+Asserts/lib/LLVMgold.so
 
-	Program executes successfully
+5. Test whether it all worked
 
-	enter 105
-	
-	Memory safety violation is triggered.
-	
-	
-    
-	
-	
-     
+   1. Compile
+
+            cd tests
+            clang -fsoftboundcets test.c -o test -L<git_repo>/softboundcets-lib -lm
+            clang -fsoftboundcets -flto test.c -o test-lto -L<git_repo>/softboundcets-lib/lto -lm
+
+   2. Run the test program
+
+            ./test
+
+      Enter 10; the program executes successfully.
+
+      Enter 105; a memory safety violation is triggered.

--- a/softboundcets-lib/Makefile
+++ b/softboundcets-lib/Makefile
@@ -1,12 +1,31 @@
 all: softboundcets_rt
 
+CFLAGS=-Wall -pedantic -O3 -D__SOFTBOUNDCETS_TRIE -D__SOFTBOUNDCETS_SPATIAL_TEMPORAL
+ARFLAGS=-rcs
 
-softboundcets_rt: softboundcets-checks.c softboundcets.c
-	clang -c -Wall -pedantic -O3 -D__SOFTBOUNDCETS_TRIE -D__SOFTBOUNDCETS_SPATIAL_TEMPORAL softboundcets-checks.c -o softboundcets-checks.o
-	clang  -c -Wall -pedantic -O3 -D__SOFTBOUNDCETS_TRIE -D__SOFTBOUNDCETS_SPATIAL_TEMPORAL softboundcets.c -o softboundcets.o
-	clang  -c -Wall -pedantic -O3 -D__SOFTBOUNDCETS_TRIE -D__SOFTBOUNDCETS_SPATIAL_TEMPORAL softboundcets-wrappers.c -o softboundcets-wrappers.o
-	ar rcs libsoftboundcets_rt.a softboundcets.o softboundcets-checks.o softboundcets-wrappers.o
+# If LLVM_GOLD is set, also build a library for use with LTO
+#
+# Note that the name of the library is hardcoded in the compiler. Thus, we call
+# it the same, but put it in the lto/ subdirectory. To use it, pass
+# -L/path/to/softboundcets-lib/lto to the compiler, and use -flto during
+# compilation and linking
+ifneq ($(LLVM_GOLD),)
+all: softboundcets_rt_lto
+endif
 
-clean: 
-	rm -rf *.o *.a *~
+softboundcets_rt: softboundcets.h softboundcets-checks.c softboundcets.c softboundcets-wrappers.c
+	clang $(CFLAGS) -c softboundcets-checks.c -o softboundcets-checks.o
+	clang $(CFLAGS) -c softboundcets.c -o softboundcets.o
+	clang $(CFLAGS) -c softboundcets-wrappers.c -o softboundcets-wrappers.o
+	ar $(ARFLAGS) libsoftboundcets_rt.a softboundcets.o softboundcets-checks.o softboundcets-wrappers.o
+
+softboundcets_rt_lto: softboundcets.h softboundcets-checks.c softboundcets.c softboundcets-wrappers.c
+	mkdir lto
+	clang $(CFLAGS) -flto -c softboundcets-checks.c -o lto/softboundcets-checks.lto.o
+	clang $(CFLAGS) -flto -c softboundcets.c -o lto/softboundcets.lto.o
+	clang $(CFLAGS) -flto -c softboundcets-wrappers.c -o lto/softboundcets-wrappers.lto.o
+	ar --plugin=$(LLVM_GOLD) $(ARFLAGS) lto/libsoftboundcets_rt.a lto/softboundcets.lto.o lto/softboundcets-checks.lto.o lto/softboundcets-wrappers.lto.o
+
+clean:
+	rm -rf *.o *.a *~ lto/
 


### PR DESCRIPTION
These two commits add support to compile libsoftboundcets_rt with as a bitcode library. This means it can then be used together with -flto, and the calls to the check functions can be inlined.

For some benchmarks, this makes a large difference. Also, all softbound papers seem to assume that checks are inlined. Here is a quick comparison using SPEC:

| Tool | SoftBound Vanilla | SoftBound LTO |
| --- | --- | --- |
| milc | 45.3 | 29.7 |
| lbm | 14.1 | 14.0 |
| bzip2 | 25.3 | 24.1 |
| sjeng | 15.0 | 11.9 |
| h264ref | 143 | 80.6 |

Hope this helps!
-- Jonas
